### PR TITLE
Release preparation

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -1,9 +1,8 @@
-name: Update gh-pages
+name: Update gh-pages (release)
 
 on:
-  push:
-    branches:
-      - main
+  release:
+    types: [created]
 
 jobs:
   build:
@@ -32,10 +31,14 @@ jobs:
     - name: Build artifacts 🏗️
       run: npm run build
 
-    - name: Deploy (to latest) 🚀
+    - name: Get react-geo-client-template version 🔖
+      run: |
+        echo "VERSION=$(node -pe "require('./package.json').version")" >> $GITHUB_ENV
+
+    - name: Deploy (to v${{ env.VERSION }}) 🚀
       uses: JamesIves/github-pages-deploy-action@v4.2.5
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         branch: gh-pages
         folder: dist
-        target-folder: latest
+        target-folder: v${{ env.VERSION }}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git@github.com:terrestris/react-geo-client-template.gitt"
+    "url": "git@github.com:terrestris/react-geo-client-template.git"
   },
   "license": "BSD-2-Clause",
   "author": "terrestris GmbH & Co. KG <info@terrestris.de>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-geo-client-template",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "private": true,
   "description": "This is a react-geo client template project",
   "keywords": [


### PR DESCRIPTION
This splits the deployment to the `gh-pages` subdirectories `latest` and `v{CLIENT_VERSION}` depending on either an update of the `main` branch or the creation of a release.

A release can easily be created by the use of the command `npx release-it`.

Please note @terrestris/devs.